### PR TITLE
drop build timestamps from png files

### DIFF
--- a/doc/examples/Makefile.am
+++ b/doc/examples/Makefile.am
@@ -74,9 +74,9 @@ DISTCLEANFILES = $(png_files) $(eps_files) $(html_files) $(txt_files) $(svg_file
 	cp $< $@
 	chmod +w $@
 %.png : %.ps
-	-convert -background white $< $@
+	-convert -strip -background white $< $@
 %-tiny.png : %.png
-	-convert -background white -geometry 90x999 $< $@
+	-convert -strip -background white -geometry 90x999 $< $@
 %.pdf : %.ps
 	convert $< $@ 
 #	ps2pdf $< $@


### PR DESCRIPTION
allowing for reproducible builds

see https://reproducible-builds.org/ for more details