### PR TITLE
more half-moon symbols; no central points in Postscript symbols

### DIFF
--- a/gri.spec
+++ b/gri.spec
@@ -97,7 +97,11 @@ then
 fi
 
 %changelog
-* (date) release 2.12.26
+* (date) release 2.12.26.fix
+- Add left and right halfmoon symbols
+- Add non-filled halfmoon symbols
+- Remove central point in Postscript symbol paths
+* 2017-jan-31 release 2.12.26
 - Fix various Debian bugs
 * 2008-jul-17 release 2.12.19
 - Fix SourceForge bug 2977816 (Fedora licensing issue)

--- a/src/draw.cc
+++ b/src/draw.cc
@@ -607,6 +607,14 @@ determine_symbol_code(const char * s)
 		return gr_filledbox_symbol;
 	else if (!strcmp(s, "bullet"))
 		return gr_bullet_symbol;
+	else if (!strcmp(s, "halfmoonup"))
+		return gr_halfmoonup_symbol;
+	else if (!strcmp(s, "halfmoonright"))
+		return gr_halfmoonright_symbol;
+	else if (!strcmp(s, "halfmoondown"))
+		return gr_halfmoondown_symbol;
+	else if (!strcmp(s, "halfmoonleft"))
+		return gr_halfmoonleft_symbol;
 	else if (!strcmp(s, "filleddiamond"))
 		return gr_filleddiamond_symbol;
 	else if (!strcmp(s, "filledtriangleup"))
@@ -619,12 +627,12 @@ determine_symbol_code(const char * s)
 		return gr_filledtriangleleft_symbol;
 	else if (!strcmp(s, "filledhalfmoonup"))
 		return gr_filledhalfmoonup_symbol;
+	else if (!strcmp(s, "filledhalfmoonright"))
+		return gr_filledhalfmoonright_symbol;
 	else if (!strcmp(s, "filledhalfmoondown"))
 		return gr_filledhalfmoondown_symbol;
-	else if (!strcmp(s, "halfmoonup"))
-		return gr_halfmoonup_symbol;
-	else if (!strcmp(s, "halfmoondown"))
-		return gr_halfmoondown_symbol;
+	else if (!strcmp(s, "filledhalfmoonleft"))
+		return gr_filledhalfmoonleft_symbol;
 	else
 		return gr_unknown_symbol;
 }

--- a/src/draw.cc
+++ b/src/draw.cc
@@ -621,6 +621,10 @@ determine_symbol_code(const char * s)
 		return gr_filledhalfmoonup_symbol;
 	else if (!strcmp(s, "filledhalfmoondown"))
 		return gr_filledhalfmoondown_symbol;
+	else if (!strcmp(s, "halfmoonup"))
+		return gr_halfmoonup_symbol;
+	else if (!strcmp(s, "halfmoondown"))
+		return gr_halfmoondown_symbol;
 	else
 		return gr_unknown_symbol;
 }

--- a/src/gr.cc
+++ b/src/gr.cc
@@ -853,6 +853,12 @@ gr_drawsymbol(double xcm, double ycm, gr_symbol_type symbol_name)
 	case gr_filledhalfmoondown_symbol:
 		fprintf(_grPS, "n %.1f %.1f m %.1f _filledhalfmoondown S\n", xpt, ypt, _grSymbolSize_pt);
 		break;
+	case gr_halfmoonup_symbol:
+		fprintf(_grPS, "n %.1f %.1f m %.1f _halfmoonup S\n", xpt, ypt, _grSymbolSize_pt);
+		break;
+	case gr_halfmoondown_symbol:
+		fprintf(_grPS, "n %.1f %.1f m %.1f _halfmoondown S\n", xpt, ypt, _grSymbolSize_pt);
+		break;
 	default:			// tiny (1.0 mm) triangle
 		{
 			double old_grSymbolSize_pt = gr_currentsymbolsize_pt();

--- a/src/gr.cc
+++ b/src/gr.cc
@@ -832,6 +832,18 @@ gr_drawsymbol(double xcm, double ycm, gr_symbol_type symbol_name)
 	case gr_bullet_symbol:
 		fprintf(_grPS, "n %.1f %.1f m %.1f _bull S\n", xpt, ypt, _grSymbolSize_pt);
 		break;
+	case gr_halfmoonup_symbol:
+		fprintf(_grPS, "n %.1f %.1f m %.1f _halfmoonup S\n", xpt, ypt, _grSymbolSize_pt);
+		break;
+	case gr_halfmoonright_symbol:
+		fprintf(_grPS, "n %.1f %.1f m %.1f _halfmoonright S\n", xpt, ypt, _grSymbolSize_pt);
+		break;
+	case gr_halfmoondown_symbol:
+		fprintf(_grPS, "n %.1f %.1f m %.1f _halfmoondown S\n", xpt, ypt, _grSymbolSize_pt);
+		break;
+	case gr_halfmoonleft_symbol:
+		fprintf(_grPS, "n %.1f %.1f m %.1f _halfmoonleft S\n", xpt, ypt, _grSymbolSize_pt);
+		break;
 	case gr_filleddiamond_symbol:
 		fprintf(_grPS, "n %.1f %.1f m %.1f _filleddiamond S\n", xpt, ypt, _grSymbolSize_pt);
 		break;
@@ -850,14 +862,14 @@ gr_drawsymbol(double xcm, double ycm, gr_symbol_type symbol_name)
 	case gr_filledhalfmoonup_symbol:
 		fprintf(_grPS, "n %.1f %.1f m %.1f _filledhalfmoonup S\n", xpt, ypt, _grSymbolSize_pt);
 		break;
+	case gr_filledhalfmoonright_symbol:
+		fprintf(_grPS, "n %.1f %.1f m %.1f _filledhalfmoonright S\n", xpt, ypt, _grSymbolSize_pt);
+		break;
 	case gr_filledhalfmoondown_symbol:
 		fprintf(_grPS, "n %.1f %.1f m %.1f _filledhalfmoondown S\n", xpt, ypt, _grSymbolSize_pt);
 		break;
-	case gr_halfmoonup_symbol:
-		fprintf(_grPS, "n %.1f %.1f m %.1f _halfmoonup S\n", xpt, ypt, _grSymbolSize_pt);
-		break;
-	case gr_halfmoondown_symbol:
-		fprintf(_grPS, "n %.1f %.1f m %.1f _halfmoondown S\n", xpt, ypt, _grSymbolSize_pt);
+	case gr_filledhalfmoonleft_symbol:
+		fprintf(_grPS, "n %.1f %.1f m %.1f _filledhalfmoonleft S\n", xpt, ypt, _grSymbolSize_pt);
 		break;
 	default:			// tiny (1.0 mm) triangle
 		{

--- a/src/gr.hh
+++ b/src/gr.hh
@@ -169,15 +169,19 @@ enum gr_symbol_type {
 	gr_star_symbol,
 	gr_filledbox_symbol,
 	gr_bullet_symbol,
+	gr_halfmoonup_symbol,
+	gr_halfmoonright_symbol,
+	gr_halfmoondown_symbol,
+	gr_halfmoonleft_symbol,
 	gr_filleddiamond_symbol,
 	gr_filledtriangleup_symbol,
 	gr_filledtriangleright_symbol,
 	gr_filledtriangledown_symbol,
 	gr_filledtriangleleft_symbol,
 	gr_filledhalfmoonup_symbol,
+	gr_filledhalfmoonright_symbol,
 	gr_filledhalfmoondown_symbol,
-	gr_halfmoonup_symbol,
-	gr_halfmoondown_symbol
+	gr_filledhalfmoonleft_symbol
 };
 
 // Color.  Is this used??

--- a/src/gr.hh
+++ b/src/gr.hh
@@ -175,7 +175,9 @@ enum gr_symbol_type {
 	gr_filledtriangledown_symbol,
 	gr_filledtriangleleft_symbol,
 	gr_filledhalfmoonup_symbol,
-	gr_filledhalfmoondown_symbol
+	gr_filledhalfmoondown_symbol,
+	gr_halfmoonup_symbol,
+	gr_halfmoondown_symbol
 };
 
 // Color.  Is this used??

--- a/src/postscpt.hh
+++ b/src/postscpt.hh
@@ -254,7 +254,7 @@ const static char *PS_dict[] =
 	" 0 t1 neg rl",
 	" t0 neg t0 rm",
 	" t1 0 rl",
-	" t0 neg 0 rm",
+//	" t0 neg 0 rm",
 	" end",
 	"} def",
 	"/timesdict 3 dict def",
@@ -266,7 +266,7 @@ const static char *PS_dict[] =
 	" t1 dup neg rl",		// lower right
 	" t1 neg 0 rm",		// lower left
 	" t1 dup rl",		// upper right
-	" t0 neg dup rm",		// centre
+//	" t0 neg dup rm",		// centre
 	" end",
 	"} def",
 	"/boxdict 3 dict def",
@@ -279,7 +279,7 @@ const static char *PS_dict[] =
 	" 0 t1 neg rl",		// bottom right 
 	" t1 neg 0 rl",		// bottom left 
 	" h",			// back to top left 
-	" t0 dup neg rm",		// end at centre 
+//	" t0 dup neg rm",		// end at centre 
 	" end",
 	"} def",
 	"/filledboxdict 3 dict def",
@@ -292,7 +292,7 @@ const static char *PS_dict[] =
 	" 0 t1 neg rl",		// bottom right 
 	" t1 neg 0 rl",		// bottom left 
 	" h",			// back to top left 
-	" t0 dup neg rm",		// end at centre 
+//	" t0 dup neg rm",		// end at centre 
 	" F end",
 	"} def",
 	"/diamonddict 2 dict def",
@@ -304,7 +304,7 @@ const static char *PS_dict[] =
 	" t0 dup neg rl",		// right 
 	" t0 neg dup rl",		// bottom 
 	" h",			// back to left 
-	" t0 0 rm",			// end at centre 
+//	" t0 0 rm",			// end at centre 
 	" end",
 	"} def",
 	"/filleddiamonddict 2 dict def",
@@ -316,7 +316,7 @@ const static char *PS_dict[] =
 	" t0 dup neg rl",		// right 
 	" t0 neg dup rl",		// bottom 
 	" h",			// back to left 
-	" t0 0 rm",			// end at centre 
+//	" t0 0 rm",			// end at centre 
 	" F end",
 	"} def",
 	"/triangleupdict 5 dict def",
@@ -330,7 +330,7 @@ const static char *PS_dict[] =
 	" t1 t2 rl",		// top 
 	" t1 t2 neg rl",		// bottom right 
 	" h",			// back to bottom left 
-	" t1 t0 rm",		// end at centre 
+//	" t1 t0 rm",		// end at centre 
 	" end",
 	"} def",
 
@@ -345,7 +345,7 @@ const static char *PS_dict[] =
 	" t1 t2 rl",		// top 
 	" t1 t2 neg rl",		// bottom right 
 	" h",			// back to bottom left 
-	" t1 t0 rm",		// end at centre 
+//	" t1 t0 rm",		// end at centre 
 	" F end",
 	"} def",
 
@@ -360,7 +360,7 @@ const static char *PS_dict[] =
 	" t2 t1 neg rl",		// right 
 	" t2 neg t1 neg rl",	// bottom 
 	" h",			// back to top 
-	" t0 t1 neg rm",		// end at centre 
+//	" t0 t1 neg rm",		// end at centre 
 	" end",
 	"} def",
 
@@ -375,7 +375,7 @@ const static char *PS_dict[] =
 	" t2 t1 neg rl",		// right 
 	" t2 neg t1 neg rl",	// bottom 
 	" h",			// back to top 
-	" t0 t1 neg rm",		// end at centre 
+//	" t0 t1 neg rm",		// end at centre 
 	" F end",
 	"} def",
 
@@ -390,7 +390,7 @@ const static char *PS_dict[] =
 	" t3 0 rl",			// top right 
 	" t1 neg t2 neg rl",	// bottom 
 	" h",			// back to top left 
-	" t1 t0 neg rm",		// end at centre 
+//	" t1 t0 neg rm",		// end at centre 
 	" end",
 	"} def",
 
@@ -405,7 +405,7 @@ const static char *PS_dict[] =
 	" t3 0 rl",			// top right 
 	" t1 neg t2 neg rl",	// bottom 
 	" h",			// back to top left 
-	" t1 t0 neg rm",		// end at centre 
+//	" t1 t0 neg rm",		// end at centre 
 	" F end",
 	"} def",
 
@@ -420,7 +420,7 @@ const static char *PS_dict[] =
 	" 0 t3 neg rl",		// bottom 
 	" t2 neg t1 rl",		// left 
 	" h",			// back to top 
-	" t0 neg t1 neg rm",	// end at centre 
+//	" t0 neg t1 neg rm",	// end at centre 
 	" end",
 	"} def",
 
@@ -435,7 +435,7 @@ const static char *PS_dict[] =
 	" 0 t3 neg rl",		// bottom 
 	" t2 neg t1 rl",		// left 
 	" h",			// back to top 
-	" t0 neg t1 neg rm",	// end at centre 
+//	" t0 neg t1 neg rm",	// end at centre 
 	" F end",
 	"} def",
 
@@ -447,7 +447,7 @@ const static char *PS_dict[] =
 	" /t2 exch def",
 	" /t1 exch def",
 	" S n t1 t2 t0 0 360 arc",
-	" t1 t2 m",
+//	" t1 t2 m",
 	" end",
 	"} def",
 
@@ -457,6 +457,24 @@ const static char *PS_dict[] =
 	" 0.5 mul /r exch def",
 	" currentpoint /y exch def /x exch def",
 	" S n x y r 0 360 arc h F S",
+	" end",
+	"} def",
+
+	"/halfmoonupdict 3 dict def",	// stack: diameter 
+	"/_halfmoonup {",
+	" bulldict begin",
+	" 0.5 mul /r exch def",
+	" currentpoint /y exch def /x exch def",
+	" S n x y r 0 180 arc h S",
+	" end",
+	"} def",
+
+	"/halfmoondowndict 3 dict def",	// stack: diameter 
+	"/_halfmoondown {",
+	" bulldict begin",
+	" 0.5 mul /r exch def",
+	" currentpoint /y exch def /x exch def",
+	" S n x y r 180 360 arc h S",
 	" end",
 	"} def",
 

--- a/src/postscpt.hh
+++ b/src/postscpt.hh
@@ -469,12 +469,30 @@ const static char *PS_dict[] =
 	" end",
 	"} def",
 
+	"/halfmoonrightdict 3 dict def",	// stack: diameter 
+	"/_halfmoonright {",
+	" bulldict begin",
+	" 0.5 mul /r exch def",
+	" currentpoint /y exch def /x exch def",
+	" S n x y r 270 90 arc h S",
+	" end",
+	"} def",
+
 	"/halfmoondowndict 3 dict def",	// stack: diameter 
 	"/_halfmoondown {",
 	" bulldict begin",
 	" 0.5 mul /r exch def",
 	" currentpoint /y exch def /x exch def",
 	" S n x y r 180 360 arc h S",
+	" end",
+	"} def",
+
+	"/halfmoonleftdict 3 dict def",	// stack: diameter 
+	"/_halfmoonleft {",
+	" bulldict begin",
+	" 0.5 mul /r exch def",
+	" currentpoint /y exch def /x exch def",
+	" S n x y r 90 270 arc h S",
 	" end",
 	"} def",
 
@@ -487,12 +505,30 @@ const static char *PS_dict[] =
 	" end",
 	"} def",
 
+	"/filledhalfmoonrightdict 3 dict def",	// stack: diameter 
+	"/_filledhalfmoonright {",
+	" bulldict begin",
+	" 0.5 mul /r exch def",
+	" currentpoint /y exch def /x exch def",
+	" S n x y r 270 90 arc h F S",
+	" end",
+	"} def",
+
 	"/filledhalfmoondowndict 3 dict def",	// stack: diameter 
 	"/_filledhalfmoondown {",
 	" bulldict begin",
 	" 0.5 mul /r exch def",
 	" currentpoint /y exch def /x exch def",
 	" S n x y r 180 360 arc h F S",
+	" end",
+	"} def",
+
+	"/filledhalfmoonleftdict 3 dict def",	// stack: diameter 
+	"/_filledhalfmoonleft {",
+	" bulldict begin",
+	" 0.5 mul /r exch def",
+	" currentpoint /y exch def /x exch def",
+	" S n x y r 90 270 arc h F S",
 	" end",
 	"} def",
 	NULL


### PR DESCRIPTION
Removed the final central point in Postscript paths of symbols. Those seem to serve no purpose but are annoying when importing the resulting PS files into, for instance, Affinity Designer, where the central point gets rendered depending on the path-end setting (round, etc.).

I was not aware of the halfmoon set of symbols and extended those to contain left and right as well as non-filled versions.